### PR TITLE
feat(themes): Rework système de thèmes : activation, vues et artisan …

### DIFF
--- a/app/Console/Commands/MakeTheme.php
+++ b/app/Console/Commands/MakeTheme.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+class MakeTheme extends Command
+{
+    protected $signature = 'make:theme {slug} {--framework=customCSS}';
+    protected $description = 'Créer un thème frontend avec un framework CSS préconfiguré (tailwind, bootstrap5, materialUI, customCSS)';
+
+    public function handle(): int
+    {
+        $slug = Str::slug($this->argument('slug'));
+        $framework = strtolower($this->option('framework') ?? 'customCSS');
+        $themePath = resource_path("themes/{$slug}");
+
+        if (File::exists($themePath)) {
+            $this->error("❌ Le thème '{$slug}' existe déjà.");
+            return 1;
+        }
+
+        $this->info("🚀 Création du thème '{$slug}' avec framework : {$framework}");
+        File::makeDirectory($themePath, 0755, true);
+
+        File::makeDirectory("{$themePath}/views");
+        File::makeDirectory("{$themePath}/assets/css", 0755, true);
+        File::makeDirectory("{$themePath}/assets/js", 0755, true);
+        File::makeDirectory("{$themePath}/public/css", 0755, true);
+        File::makeDirectory("{$themePath}/public/js", 0755, true);
+        File::makeDirectory("{$themePath}/config");
+
+        File::put("{$themePath}/theme.json", json_encode([
+            'name' => Str::headline($slug),
+            'slug' => $slug,
+            'version' => '1.0.0',
+            'author' => config('app.name'),
+            'description' => 'Thème personnalisé généré par artisan',
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+        File::put("{$themePath}/views/home.blade.php", "<h1>Bienvenue sur le thème <strong>{$slug}</strong></h1>");
+
+        match ($framework) {
+            'tailwind' => $this->setupTailwind($themePath),
+            'bootstrap5' => $this->setupBootstrap($themePath),
+            'materialui' => $this->setupMaterialUI($themePath),
+            default => $this->setupCustomCSS($themePath),
+        };
+
+        $this->info("✅ Thème '{$slug}' généré avec succès !");
+        return 0;
+    }
+
+    protected function setupTailwind(string $path): void
+    {
+        $this->info("📦 Configuration TailwindCSS...");
+
+        File::put("{$path}/tailwind.config.js", <<<JS
+module.exports = {
+    content: ["./views/**/*.blade.php"],
+    theme: {
+        extend: {},
+    },
+    plugins: [],
+}
+JS);
+
+        File::put("{$path}/postcss.config.js", <<<JS
+module.exports = {
+    plugins: {
+        tailwindcss: {},
+        autoprefixer: {},
+    }
+}
+JS);
+
+        File::put("{$path}/assets/css/app.css", <<<CSS
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+CSS);
+    }
+
+    protected function setupBootstrap(string $path): void
+    {
+        $this->info("📦 Configuration Bootstrap 5...");
+
+        File::put("{$path}/assets/css/app.css", <<<CSS
+@import url('https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css');
+CSS);
+
+        File::put("{$path}/assets/js/app.js", <<<JS
+import 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js';
+JS);
+    }
+
+    protected function setupMaterialUI(string $path): void
+    {
+        $this->info("📦 Configuration Material UI...");
+
+        File::put("{$path}/assets/css/app.css", <<<CSS
+@import url('https://fonts.googleapis.com/icon?family=Material+Icons');
+@import url('https://cdn.jsdelivr.net/npm/material-components-web@latest/dist/material-components-web.min.css');
+CSS);
+
+        File::put("{$path}/assets/js/app.js", <<<JS
+import 'https://cdn.jsdelivr.net/npm/material-components-web@latest/dist/material-components-web.min.js';
+JS);
+    }
+
+    protected function setupCustomCSS(string $path): void
+    {
+        $this->info("📦 Configuration CSS personnalisé...");
+
+        File::put("{$path}/assets/css/app.css", <<<CSS
+/* Ajoutez ici votre CSS personnalisé */
+body {
+    font-family: sans-serif;
+    padding: 2rem;
+}
+CSS);
+    }
+}

--- a/app/Console/Commands/ThemeCssCompile.php
+++ b/app/Console/Commands/ThemeCssCompile.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Process\Process;
+
+class ThemeCssCompile extends Command
+{
+    protected $signature = 'theme:css:compile {slug} {file=app.css} {--minify}';
+    protected $description = 'Compile le CSS du thème (ex : Tailwind) avec option --minify';
+
+    public function handle(): int
+    {
+        $slug = $this->argument('slug');
+        $file = $this->argument('file');
+        $minify = $this->option('minify');
+        $themePath = resource_path("themes/{$slug}");
+
+        if (!File::exists($themePath)) {
+            $this->error("❌ Le thème '{$slug}' n'existe pas.");
+            return 1;
+        }
+
+        $cssPath = "{$themePath}/assets/css/{$file}";
+        $outputPath = "{$themePath}/public/css/{$file}";
+
+        File::ensureDirectoryExists(dirname($outputPath));
+
+        $tailwindConfig = "{$themePath}/tailwind.config.js";
+        if (File::exists($tailwindConfig)) {
+            return $this->compileTailwind($themePath, $cssPath, $outputPath, $tailwindConfig, $minify);
+        }
+
+        $this->error("❌ Aucun système de compilation supporté détecté pour '{$slug}' (ex: tailwind.config.js manquant)");
+        return 1;
+    }
+
+    protected function compileTailwind(string $themePath, string $input, string $output, string $config, bool $minify): int
+    {
+        if (!File::exists($input)) {
+            $this->error("❌ Fichier CSS source introuvable : {$input}");
+            return 1;
+        }
+
+        $cmd = [
+            'npx', 'tailwindcss',
+            '-i', $input,
+            '-o', $output,
+            '--config', $config,
+        ];
+
+        if ($minify) {
+            $cmd[] = '--minify';
+        }
+
+        $process = new Process($cmd, $themePath);
+        $process->setTimeout(60);
+
+        $this->info("🚀 Compilation de Tailwind CSS...");
+        $process->run(function ($type, $buffer) {
+            echo $buffer;
+        });
+
+        if (!$process->isSuccessful()) {
+            $this->error("❌ Échec de la compilation Tailwind.");
+            return 1;
+        }
+
+        $this->info("✅ CSS compilé avec succès : {$output}");
+        return 0;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Models\Theme;
 use App\Support\ModuleNavigationManager;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
@@ -113,6 +114,11 @@ class AppServiceProvider extends ServiceProvider
         if (\Schema::hasTable('modules')) {
             \App\Support\ModuleManager::registerActiveModules();
         }
+
+        if (File::isDirectory(resource_path('themes'))) {
+            app(\App\Support\ThemeManager::class)->registerViewNamespaces();
+        }
+
 
     }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -18,7 +18,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/dashboard';
+    public const HOME = '/profile';
 
     /**
      * Define your route model bindings, pattern filters, and other route configuration.

--- a/app/Support/ThemeManager.php
+++ b/app/Support/ThemeManager.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Theme;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\View;
+
+class ThemeManager
+{
+    protected string $themesPath;
+
+    public function __construct()
+    {
+        $this->themesPath = resource_path('themes');
+    }
+
+    public function scan(): void
+    {
+        $directories = File::directories($this->themesPath);
+
+        foreach ($directories as $dir) {
+            $manifestPath = $dir . '/theme.json';
+            if (!File::exists($manifestPath)) continue;
+
+            $manifest = json_decode(File::get($manifestPath), true);
+            if (!isset($manifest['slug'])) continue;
+
+            Theme::updateOrCreate(
+                ['slug' => $manifest['slug']],
+                [
+                    'name' => $manifest['name'] ?? ucfirst($manifest['slug']),
+                    'version' => $manifest['version'] ?? '1.0.0',
+                    'author' => $manifest['author'] ?? 'Anonyme',
+                    'description' => $manifest['description'] ?? '',
+                    'path' => 'themes/' . basename($dir),
+                ]
+            );
+        }
+    }
+
+    public function activate(string $slug): bool
+    {
+        $theme = Theme::where('slug', $slug)->first();
+        if (!$theme) return false;
+
+        Theme::where('active', true)->update(['active' => false]);
+        $theme->update(['active' => true]);
+
+        return true;
+    }
+
+    public function deactivate(string $slug): bool
+    {
+        $theme = Theme::where('slug', $slug)->first();
+        if (!$theme) return false;
+
+        $theme->update(['active' => false]);
+        return true;
+    }
+
+
+    public function registerViewNamespaces(): void
+    {
+        $theme = Theme::where('active', true)->first();
+        if (!$theme) return;
+
+        $themeViews = resource_path("themes/{$theme->slug}/views");
+        $themeRoot = resource_path("themes/{$theme->slug}");
+
+        View::flushFinderCache();
+
+        View::getFinder()->prependLocation($themeViews);
+
+        View::addNamespace('theme', $themeViews);
+        View::addNamespace('themes', $themeRoot);
+
+        config(['theme.assets' => asset("themes-assets/{$theme->slug}/assets")]);
+    }
+
+}


### PR DESCRIPTION
…commands

Refonte de l'activation / désactivation de thème
- Correction : un thème désactivé ne force plus le fallback sur "default"
- Utilisation correcte des vues `resources/views/` si aucun thème actif

Support complet des vues personnalisées
- `theme_view()` utilise `theme::<view>` si actif, sinon fallback sur `<view>`
- `theme_asset()` et `theme_config()` correctement intégrés

Nouvelles commandes Artisan
- `make:theme {slug} --framework=` : génération de thème avec choix Tailwind/Bootstrap/Material/Custom
- Génération automatique des fichiers de config (tailwind.config.js, postcss.config.js, etc.)
- `theme:css:compile {slug} {fichier.css}` : compilation Tailwind avec option `--minify`